### PR TITLE
Add new request field to specify whether the Connect API should emit …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2018-03-26 Release 5.0.0
+
+    Add field to stream descriptor to request OFFSET_UPDATE events.
+
 2017-12-19 Release 4.1.3
 
     Add Exception logging for non-ConnectionException failures

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add the following to your pom.xml
 Usage
 =====
 
-The client library provides all the components you need to consume a mobile event stream.
+The client library provides all the components you need to consume a Connect direct stream.
 
 _Note that Connect requests with this client may experience SSL handshake failures unless using the
 **Java Cryptography Extension (JCE) Unlimited Strength** package cipher suite._
@@ -71,7 +71,7 @@ Example
             .build();
 ```
 ```
-        // can also set eagle creek filter, subset, or offset specifications
+        // can also set filter, subset, or offset specifications
         StreamQueryDescriptor descriptor = StreamQueryDescriptor.newBuilder()
             .setCreds(creds)
             .build();
@@ -107,7 +107,13 @@ StreamQueryDescriptor
 ---------------------
 
 Begin by creating a StreamQueryDescriptor instance.  This will contain the app credentials, any request filters,
- a starting offset, and any subset options.
+ a starting offset, offset update preference, and any subset options.
+
+If offset updates are enabled, then regardless of other filters provided the stream may contain events with type
+OFFSET_UPDATE. These don't correspond to any activity in Urban Airship's systems and requests for the same stream
+position will not return the same OFFSET_UPDATE events. The offsets on them will be the same as some other event
+in the stream. They serve to allow clients to update stored offsets in the case of low traffic or filters removing
+large portions of the stream.
 
 First, store the app credentials (app key and auth token) in a Creds object:
 
@@ -151,6 +157,7 @@ Next, you will want to build any request filters or subset.  See the request doc
             .setCreds(creds)
             .addFilters(filter)
             .setSubset(subset)
+            .enableOffsetUpdates()
             .build();
 ```
 

--- a/src/main/java/com/urbanairship/connect/client/StreamConnection.java
+++ b/src/main/java/com/urbanairship/connect/client/StreamConnection.java
@@ -317,7 +317,9 @@ public class StreamConnection implements AutoCloseable {
     }
 
     private byte[] getQuery(Optional<StartPosition> position) {
-        StreamRequestPayload payload = new StreamRequestPayload(descriptor.getFilters(), descriptor.getSubset(), position);
+        StreamRequestPayload payload =
+                new StreamRequestPayload(descriptor.getFilters(), descriptor.getSubset(), position, descriptor.offsetUpdatesEnabled());
+
         String json = GSON.toJson(payload);
 
         return json.getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/com/urbanairship/connect/client/model/StreamQueryDescriptor.java
+++ b/src/main/java/com/urbanairship/connect/client/model/StreamQueryDescriptor.java
@@ -24,6 +24,7 @@ public final class StreamQueryDescriptor {
     private final Creds creds;
     private final Set<Filter> filters;
     private final Optional<Subset> subset;
+    private final Optional<Boolean> offsetUpdatesEnabled;
 
     /**
      * StreamDescriptor builder
@@ -33,10 +34,11 @@ public final class StreamQueryDescriptor {
         return new Builder();
     }
 
-    private StreamQueryDescriptor(Creds creds, Set<Filter> filters, Optional<Subset> subset) {
+    private StreamQueryDescriptor(Creds creds, Set<Filter> filters, Optional<Subset> subset, Optional<Boolean> offsetUpdatesEnabled) {
         this.creds = creds;
         this.filters = filters;
         this.subset = subset;
+        this.offsetUpdatesEnabled = offsetUpdatesEnabled;
     }
 
     /**
@@ -66,6 +68,15 @@ public final class StreamQueryDescriptor {
         return subset;
     }
 
+    /**
+     * Get offset update enabled status
+     *
+     * @return Absent if no override is specified otherwise true if offset update events are enabled, false otherwise
+     */
+    public Optional<Boolean> offsetUpdatesEnabled() {
+        return offsetUpdatesEnabled;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -91,6 +102,7 @@ public final class StreamQueryDescriptor {
 
         private Creds creds = null;
         private Subset subset = null;
+        private Optional<Boolean> offsetUpdatesEnabled = Optional.absent();
 
         private Builder() {}
 
@@ -128,13 +140,33 @@ public final class StreamQueryDescriptor {
         }
 
         /**
+         * Enable offset updates
+         *
+         * @return Builder
+         */
+        public Builder enableOffsetUpdates() {
+            this.offsetUpdatesEnabled = Optional.of(true);
+            return this;
+        }
+
+        /**
+         * Disable offset updates
+         *
+         * @return Builder
+         */
+        public Builder disableOffsetUpdates() {
+            this.offsetUpdatesEnabled = Optional.of(false);
+            return this;
+        }
+
+        /**
          * Builder a StreamDescriptor object.
          * @return StreamDescriptor
          */
         public StreamQueryDescriptor build() {
             Preconditions.checkNotNull(creds, "Creds object must be provided");
 
-            return new StreamQueryDescriptor(creds, ImmutableSet.copyOf(filters), Optional.fromNullable(subset));
+            return new StreamQueryDescriptor(creds, ImmutableSet.copyOf(filters), Optional.fromNullable(subset), offsetUpdatesEnabled);
         }
     }
 }

--- a/src/main/java/com/urbanairship/connect/client/model/request/StreamRequestPayload.java
+++ b/src/main/java/com/urbanairship/connect/client/model/request/StreamRequestPayload.java
@@ -1,6 +1,5 @@
 package com.urbanairship.connect.client.model.request;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -17,11 +16,14 @@ public final class StreamRequestPayload {
     private final Set<Filter> filters;
     private final Optional<Subset> subset;
     private final Optional<StartPosition> startPosition;
+    private final Optional<Boolean> offsetUpdatesEnabled;
 
-    public StreamRequestPayload(Set<Filter> filters, Optional<Subset> subset, Optional<StartPosition> startPosition) {
+    public StreamRequestPayload(Set<Filter> filters, Optional<Subset> subset, Optional<StartPosition> startPosition,
+                                Optional<Boolean> offsetUpdatesEnabled) {
         this.filters = filters;
         this.subset = subset;
         this.startPosition = startPosition;
+        this.offsetUpdatesEnabled = offsetUpdatesEnabled;
     }
 
     public Set<Filter> getFilters() {
@@ -36,38 +38,41 @@ public final class StreamRequestPayload {
         return startPosition;
     }
 
+    public Optional<Boolean> offsetUpdatesEnabled() {
+        return offsetUpdatesEnabled;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (!(o instanceof StreamRequestPayload)) return false;
         StreamRequestPayload that = (StreamRequestPayload) o;
-        return Objects.equals(filters, that.filters) &&
+        return offsetUpdatesEnabled == that.offsetUpdatesEnabled &&
+                Objects.equals(filters, that.filters) &&
                 Objects.equals(subset, that.subset) &&
                 Objects.equals(startPosition, that.startPosition);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(filters, subset, startPosition);
+        return Objects.hash(filters, subset, startPosition, offsetUpdatesEnabled);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                .add("filters", filters)
-                .add("subset", subset)
-                .add("startPosition", startPosition)
-                .toString();
+        return "StreamRequestPayload{" +
+                "filters=" + filters +
+                ", subset=" + subset +
+                ", startPosition=" + startPosition +
+                ", offsetUpdatesEnabled=" + offsetUpdatesEnabled +
+                '}';
     }
 
     public static final String FILTERS_KEY = "filters";
     public static final String START_KEY = "start";
     public static final String RESUME_OFFSET_KEY = "resume_offset";
     public static final String SUBSET_KEY = "subset";
+    public static final String OFFSET_UPDATE_KEY = "enable_offset_updates";
 
     public static final JsonSerializer<StreamRequestPayload> SERIALIZER = new JsonSerializer<StreamRequestPayload>() {
         @Override
@@ -90,6 +95,10 @@ public final class StreamRequestPayload {
 
             if (streamRequestPayload.getSubset().isPresent()) {
                 obj.add(SUBSET_KEY, context.serialize(streamRequestPayload.getSubset().get()));
+            }
+
+            if (streamRequestPayload.offsetUpdatesEnabled().isPresent()) {
+                obj.addProperty(OFFSET_UPDATE_KEY, streamRequestPayload.offsetUpdatesEnabled().get());
             }
 
             return obj;

--- a/src/test/java/com/urbanairship/connect/client/StreamConnectionTest.java
+++ b/src/test/java/com/urbanairship/connect/client/StreamConnectionTest.java
@@ -419,6 +419,48 @@ public class StreamConnectionTest {
         assertEquals(gson.toJson(subset), gson.toJson(bodyObj.get("subset")));
     }
 
+    @Test
+    public void testRequestBodyWithOffsetUpdates() throws Exception {
+        final AtomicReference<String> body = new AtomicReference<>();
+        final CountDownLatch received = new CountDownLatch(1);
+        Answer httpAnswer = new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                HttpExchange exchange = (HttpExchange) invocation.getArguments()[0];
+
+                int length = Integer.parseInt(exchange.getRequestHeaders().getFirst(HttpHeaders.CONTENT_LENGTH));
+                byte[] bytes = new byte[length];
+                exchange.getRequestBody().read(bytes);
+                body.set(new String(bytes, UTF_8));
+
+                exchange.sendResponseHeaders(200, 0L);
+                received.countDown();
+
+                return null;
+            }
+        };
+        doAnswer(httpAnswer).when(serverHandler).handle(Matchers.<HttpExchange>any());
+
+        StreamQueryDescriptor descriptor = StreamQueryDescriptor.newBuilder()
+                .setCreds( Creds.newBuilder()
+                        .setAppKey(randomAlphabetic(22))
+                        .setToken(randomAlphabetic(5))
+                        .build())
+                .enableOffsetUpdates()
+                .build();
+
+        stream = new StreamConnection(descriptor, http, connectionRetryStrategy, consumer, url);
+        read(stream, Optional.<StartPosition>absent());
+
+        assertTrue(received.await(10, TimeUnit.SECONDS));
+
+        Gson gson = GsonUtil.getGson();
+
+        JsonObject bodyObj = parser.parse(body.get()).getAsJsonObject();
+        assertEquals(true, bodyObj.get("enable_offset_updates").getAsBoolean());
+    }
+
+
     @Rule public ExpectedException expectedException = ExpectedException.none();
 
     @Test

--- a/src/test/java/com/urbanairship/connect/client/model/request/StreamRequestPayloadSerializationTest.java
+++ b/src/test/java/com/urbanairship/connect/client/model/request/StreamRequestPayloadSerializationTest.java
@@ -18,7 +18,7 @@ public class StreamRequestPayloadSerializationTest {
     private static final JsonParser parser = new JsonParser();
 
     @Test
-    public void testSerialization() throws Exception {
+    public void testSerialization() {
         StreamRequestPayload payload = new StreamRequestPayload(
                 ImmutableSet.of(Filter.newBuilder().addEventTypes("OPEN").build()),
                 Optional.of(Subset.createPartitionSubset()
@@ -26,7 +26,8 @@ public class StreamRequestPayloadSerializationTest {
                         .setSelection(5)
                         .build()
                 ),
-                Optional.of(StartPosition.relative(StartPosition.RelativePosition.EARLIEST))
+                Optional.of(StartPosition.relative(StartPosition.RelativePosition.EARLIEST)),
+                Optional.of(true)
         );
 
         JsonElement obj = GsonUtil.getGson().toJsonTree(payload);
@@ -40,7 +41,8 @@ public class StreamRequestPayloadSerializationTest {
                     "\"count\":10," +
                     "\"selection\":5" +
                 "}," +
-                "\"start\":\"EARLIEST\"" +
+                "\"start\":\"EARLIEST\"," +
+                "\"enable_offset_updates\": true" +
             "}";
 
         JsonElement expected = parser.parse(json);
@@ -49,33 +51,39 @@ public class StreamRequestPayloadSerializationTest {
     }
 
     @Test
-    public void testStartPositions() throws Exception {
-        StreamRequestPayload payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.of(StartPosition.relative(StartPosition.RelativePosition.EARLIEST)));
+    public void testStartEarliest() {
+        StreamRequestPayload payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.of(StartPosition.relative(StartPosition.RelativePosition.EARLIEST)), Optional.<Boolean>absent());
 
         JsonElement obj = GsonUtil.getGson().toJsonTree(payload);
         JsonElement expected = parser.parse("{\"start\":\"EARLIEST\"}");
 
         assertEquals(expected, obj);
+    }
 
-        payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.of(StartPosition.relative(StartPosition.RelativePosition.LATEST)));
+    @Test
+    public void testStartLatest() {
+        StreamRequestPayload payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.of(StartPosition.relative(StartPosition.RelativePosition.LATEST)), Optional.<Boolean>absent());
 
-        obj = GsonUtil.getGson().toJsonTree(payload);
-        expected = parser.parse("{\"start\":\"LATEST\"}");
-
-        assertEquals(expected, obj);
-
-        long offset = RandomUtils.nextLong(10L, 10000L);
-        payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.of(StartPosition.offset(offset)));
-
-        obj = GsonUtil.getGson().toJsonTree(payload);
-        expected = parser.parse(String.format("{\"resume_offset\":%d}", offset));
+        JsonElement obj = GsonUtil.getGson().toJsonTree(payload);
+        JsonElement expected = parser.parse("{\"start\":\"LATEST\"}");
 
         assertEquals(expected, obj);
     }
 
     @Test
-    public void testEmptyPayload() throws Exception {
-        StreamRequestPayload payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.<StartPosition>absent());
+    public void testStartAbsolute() {
+        long offset = RandomUtils.nextLong(10L, 10000L);
+        StreamRequestPayload payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.of(StartPosition.offset(offset)), Optional.<Boolean>absent());
+
+        JsonElement obj = GsonUtil.getGson().toJsonTree(payload);
+        JsonElement expected = parser.parse(String.format("{\"resume_offset\":%d}", offset));
+
+        assertEquals(expected, obj);
+    }
+
+    @Test
+    public void testEmptyPayload() {
+        StreamRequestPayload payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.<StartPosition>absent(), Optional.<Boolean>absent());
 
         JsonElement obj = GsonUtil.getGson().toJsonTree(payload);
         JsonElement expected = parser.parse("{}");


### PR DESCRIPTION
…a new OFFSET_UPDATE event type in the case of slow moving streams.

### What does this do and why?
Enables clients to set the new enable_offset_updates flag on requests, which causes the backend 
to emit OFFSET_UPDATE events in place of newlines for keepalive on slow moving streams. This should help issues such as REPORTS-168/CUSTENG-173

### Additional notes for reviewers
* The default behavior in the client is to omit the flag, and the default on the server side will always be 
   the existing behavior.

### Testing
- [x] I wrote tests covering these changes  
- [x] I ran the full test suite and it passed

### Test run results, including date and time:

03-26-2018T13:37
Tests run: 54, Failures: 0, Errors: 0, Skipped: 0

### Urban Airship Contribution Agreement
https://docs.urbanairship.com/contribution-agreement/

- [x] I've filled out and signed UA's contribution agreement form.