### PR TITLE
Update offset handling to expect a String

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 
     Add field to stream descriptor to request OFFSET_UPDATE events.
 
+    Resume offsets are not necessarily numeric, and should be stored as Strings.
+
 2017-12-19 Release 4.1.3
 
     Add Exception logging for non-ConnectionException failures

--- a/src/main/java/com/urbanairship/connect/client/model/request/StartPosition.java
+++ b/src/main/java/com/urbanairship/connect/client/model/request/StartPosition.java
@@ -2,6 +2,7 @@ package com.urbanairship.connect.client.model.request;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Objects;
 
@@ -39,8 +40,8 @@ public final class StartPosition {
      * @param offset the offset specifying the position. An offset can be retrieved from the body of an event received from
      *               the Urban Airship Connect API and specifies that event's position in the overall stream.
      */
-    public static StartPosition offset(long offset) {
-        Preconditions.checkArgument(offset >= 0, "Offset cannot be negative");
+    public static StartPosition offset(String offset) {
+        Preconditions.checkArgument(StringUtils.isNotBlank(offset), "Offset cannot be null or empty");
         return new StartPosition(null, offset);
     }
 
@@ -51,13 +52,13 @@ public final class StartPosition {
      */
     public static StartPosition relative(RelativePosition position) {
         Preconditions.checkNotNull(position);
-        return new StartPosition(position, -1L);
+        return new StartPosition(position, "");
     }
 
     private final RelativePosition relativePosition;
-    private final long offset;
+    private final String offset;
 
-    private StartPosition(RelativePosition relativePosition, long offset) {
+    private StartPosition(RelativePosition relativePosition, String offset) {
         this.relativePosition = relativePosition;
         this.offset = offset;
     }
@@ -71,22 +72,18 @@ public final class StartPosition {
         return relativePosition;
     }
 
-    public long getOffset() {
+    public String getOffset() {
         Preconditions.checkState(relativePosition == null, "Start position is relative");
         return offset;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (!(o instanceof StartPosition)) return false;
         StartPosition that = (StartPosition) o;
-        return offset == that.offset &&
-                relativePosition == that.relativePosition;
+        return relativePosition == that.relativePosition &&
+                Objects.equals(offset, that.offset);
     }
 
     @Override

--- a/src/test/java/com/urbanairship/connect/client/StreamConnectionTest.java
+++ b/src/test/java/com/urbanairship/connect/client/StreamConnectionTest.java
@@ -30,6 +30,7 @@ import com.urbanairship.connect.client.model.request.filters.DeviceType;
 import com.urbanairship.connect.client.model.request.filters.Filter;
 import com.urbanairship.connect.client.model.request.filters.NotificationFilter;
 import com.urbanairship.connect.java8.Consumer;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -244,7 +245,7 @@ public class StreamConnectionTest {
 
         doAnswer(httpAnswer).when(serverHandler).handle(Matchers.<HttpExchange>any());
 
-        long offset = RandomUtils.nextInt(0, 100000);
+        String offset = RandomStringUtils.randomAlphanumeric(32);
         StreamQueryDescriptor descriptor = descriptor();
 
         stream = new StreamConnection(descriptor, http, connectionRetryStrategy, consumer, url);
@@ -253,7 +254,7 @@ public class StreamConnectionTest {
         assertTrue(received.await(10, TimeUnit.SECONDS));
 
         JsonObject bodyObj = parser.parse(body.get()).getAsJsonObject();
-        assertEquals(offset, bodyObj.get("resume_offset").getAsLong());
+        assertEquals(offset, bodyObj.get("resume_offset").getAsString());
     }
 
     @Test
@@ -453,8 +454,6 @@ public class StreamConnectionTest {
         read(stream, Optional.<StartPosition>absent());
 
         assertTrue(received.await(10, TimeUnit.SECONDS));
-
-        Gson gson = GsonUtil.getGson();
 
         JsonObject bodyObj = parser.parse(body.get()).getAsJsonObject();
         assertEquals(true, bodyObj.get("enable_offset_updates").getAsBoolean());

--- a/src/test/java/com/urbanairship/connect/client/StreamConsumeTaskTest.java
+++ b/src/test/java/com/urbanairship/connect/client/StreamConsumeTaskTest.java
@@ -14,6 +14,7 @@ import com.urbanairship.connect.client.model.GsonUtil;
 import com.urbanairship.connect.client.model.StreamQueryDescriptor;
 import com.urbanairship.connect.client.model.request.StartPosition;
 import com.urbanairship.connect.java8.Consumer;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,9 +55,6 @@ public class StreamConsumeTaskTest {
 
     private StreamConsumeTask task;
 
-    @Mock private Consumer<String> consumer;
-
-    @Mock private AsyncHttpClient http;
     @Mock private StreamConnectionSupplier supplier;
     @Mock private StreamConnection stream;
 
@@ -189,7 +187,7 @@ public class StreamConsumeTaskTest {
 
     @Test
     public void testSpecifiedStartPosition() throws Exception {
-        StartPosition position = StartPosition.offset(12355L);
+        StartPosition position = StartPosition.offset(RandomStringUtils.randomAlphanumeric(32));
         task = StreamConsumeTask.newBuilder()
                 .setStreamQueryDescriptor(descriptor())
                 .setStreamConnectionSupplier(supplier)
@@ -388,10 +386,11 @@ public class StreamConsumeTaskTest {
         List<TestEvent> events = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             JsonObject o = new JsonObject();
-            o.addProperty("offset", i);
+            final String offset = Integer.toString(i);
+            o.addProperty("offset", offset);
 
             String json = GsonUtil.getGson().toJson(o);
-            events.add(new TestEvent(i, json));
+            events.add(new TestEvent(offset, json));
         }
 
         return events;
@@ -426,10 +425,10 @@ public class StreamConsumeTaskTest {
 
     private static class TestEvent {
 
-        private final long offset;
+        private final String offset;
         private final String json;
 
-        public TestEvent(long offset, String json) {
+        public TestEvent(String offset, String json) {
             this.offset = offset;
             this.json = json;
         }

--- a/src/test/java/com/urbanairship/connect/client/model/request/StreamRequestPayloadSerializationTest.java
+++ b/src/test/java/com/urbanairship/connect/client/model/request/StreamRequestPayloadSerializationTest.java
@@ -6,7 +6,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.urbanairship.connect.client.model.GsonUtil;
 import com.urbanairship.connect.client.model.request.filters.Filter;
-import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -72,11 +72,11 @@ public class StreamRequestPayloadSerializationTest {
 
     @Test
     public void testStartAbsolute() {
-        long offset = RandomUtils.nextLong(10L, 10000L);
+        String offset = RandomStringUtils.randomAlphanumeric(32);
         StreamRequestPayload payload = new StreamRequestPayload(Collections.<Filter>emptySet(), Optional.<Subset>absent(), Optional.of(StartPosition.offset(offset)), Optional.<Boolean>absent());
 
         JsonElement obj = GsonUtil.getGson().toJsonTree(payload);
-        JsonElement expected = parser.parse(String.format("{\"resume_offset\":%d}", offset));
+        JsonElement expected = parser.parse(String.format("{\"resume_offset\":\"%s\"}", offset));
 
         assertEquals(expected, obj);
     }


### PR DESCRIPTION
### What does this do and why?
Offsets were always intended to be opaque, but this wasn't reflected in the docs or this client. The docs have been updated, but clients have not yet been forced to change.

### Additional notes for reviewers
* This is a breaking change, and will be a major version release

### Testing
- [x] I wrote tests covering these changes  
- [x] I ran the full test suite and it passed

### Test run results, including date and time:

2018-03-28T14:00
Results :
Tests run: 54, Failures: 0, Errors: 0, Skipped: 0