### PR TITLE
Add logs for CUSTENG-292

### DIFF
--- a/src/main/java/com/urbanairship/connect/client/Stream.java
+++ b/src/main/java/com/urbanairship/connect/client/Stream.java
@@ -44,7 +44,7 @@ public final class Stream extends AbstractIterator<String> implements ConnectStr
 
     public Stream(StreamQueryDescriptor descriptor, Optional<StartPosition> startingPosition) {
         this(descriptor, startingPosition, Optional.<StreamConnectionSupplier>absent());
-        log.debug("Stream. Filters: " + descriptor.getFilters()
+        log.debug("Stream Filters: " + descriptor.getFilters()
                 + " Subset: " + descriptor.getSubset()
                 + " Starting Position " + startingPosition);
     }

--- a/src/main/java/com/urbanairship/connect/client/StreamConsumeTask.java
+++ b/src/main/java/com/urbanairship/connect/client/StreamConsumeTask.java
@@ -118,7 +118,7 @@ public final class StreamConsumeTask implements Runnable {
 
     private Optional<StartPosition> getPosition() {
         Optional<String> lastOffset = consumer.get();
-        log.debug("Consumer last offset: " + consumer.lastOffset + ", InitialPosition: " + initialPosition + ", Last Offset: " + lastOffset);
+        log.debug("Consumer last offset: " + consumer.lastOffset + ", InitialPosition: " + initialPosition);
         if (lastOffset.isPresent()) {
             return Optional.of(StartPosition.offset(lastOffset.get()));
         }


### PR DESCRIPTION

* This adds additional logging for troubleshooting
Test run:
```
[Stream iteration thread 0] INFO com.urbanairship.connect.client.StreamConsumeTask - Starting run
[main] DEBUG com.urbanairship.connect.client.Stream - Starting Stream. Filters: [] Subset: Optional.absent() Starting Position Optional.of(StartPosition{relativePosition=null, offset=1002648894678})
[Stream iteration thread 0] DEBUG com.urbanairship.connect.client.StreamConsumeTask - getPosition - Consumer: com.urbanairship.connect.client.StreamConsumeTask$EnqueuingConsumer@33371f2d InitialPosition: Optional.of(StartPosition{relativePosition=null, offset=1002648894678}) Last Offset: Optional.absent()
[Stream iteration thread 0] DEBUG com.urbanairship.connect.client.StreamConsumeTask - stream position: Optional.of(StartPosition{relativePosition=null, offset=1002648894678})
[pool-5-thread-1] INFO com.urbanairship.connect.client.StreamConsumeTask - Shutting down stream handler for app JhYcm4waRZy5QCIgBykCSA
[Stream iteration thread 0] DEBUG com.urbanairship.connect.client.StreamConsumeTask - Stopping run
```

