### PR TITLE
Duplicate requests

### DIFF
--- a/src/main/java/com/urbanairship/connect/client/HttpClientUtil.java
+++ b/src/main/java/com/urbanairship/connect/client/HttpClientUtil.java
@@ -18,6 +18,9 @@ public final class HttpClientUtil {
 
     /**
      * Builds an AsyncHttpClient with default settings
+     * The setMaxRequestRetry will be handled by the StreamConsumeTask.
+     * Allowing the Aysnc client to handle the re-request will result in the same start offset being requested,
+     * even if the connection has been processing for hours.
      * @return An AsyncHttpClient instance.
      */
     public static AsyncHttpClient defaultHttpClient() {
@@ -28,6 +31,7 @@ public final class HttpClientUtil {
             .setRequestTimeout(-1)
             .setAllowPoolingConnections(false)
             .setAllowPoolingSslConnections(false)
+            .setMaxRequestRetry(0)
             .build();
 
         return new AsyncHttpClient(clientConfig);


### PR DESCRIPTION
REPORTS-228

https://urbanairship.atlassian.net/browse/REPORTS-228
Customers have been experiencing duplicate data.  This is being caused by a flapping network which causes com.ning.http.client.AsyncHttpClient to retry the request with the original offset even if the connection has been open for a long time.  This is due to the nature of an HTTP request/response and the implementation used by Connect.  An HTTP request/response is not considered finished until the entire response is downloaded; however, the Connect response will never finish. Thus AsyncHttpClient will see this as a failed request attempt and will retry up to the default of 5 times.

The AsyncHttpClient config of setMaxRequestRetry is set to 0 since connection retries will be handled by the Connect code.


It is a bit tricky to duplicate this problem as it requires break-points in the async-http-client library. Specifically on the NettyResponseFuture.canBeReplayed() method.  
1.) Create a connection to Connect (turn off tunnelblick).
2.) Place break-point mentioned above.
3.) Unplug network connection to computer.
4.) Breakpoint should be hit within a minute or so (sometimes breakpoints in libraries are missed).
5.) Wait a couple of minutes at the breakpoint.
6.) Plug network connection in.
7.) Should see a replay of previous data.