### PR TITLE
Add support for specifying connect endpoint URL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2019-05-29 Release 5.1.0
+
+    Add support for specifying an alternate endpoint URL for stream consumption.
+
 2018-06-21 Release 5.0.2
 
     Set AsyncHttpClient Max Request Retry to 0 to better handle disconnects and not restart at old offsets.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ StreamQueryDescriptor
 ---------------------
 
 Begin by creating a StreamQueryDescriptor instance.  This will contain the app credentials, any request filters,
- a starting offset, offset update preference, and any subset options.
+ a starting offset, offset update preference, endpoint URL, and any subset options.
 
 If offset updates are enabled, then regardless of other filters provided the stream may contain events with type
 OFFSET_UPDATE. These don't correspond to any activity in Urban Airship's systems and requests for the same stream

--- a/src/main/java/com/urbanairship/connect/client/Constants.java
+++ b/src/main/java/com/urbanairship/connect/client/Constants.java
@@ -3,6 +3,7 @@ package com.urbanairship.connect.client;
 public final class Constants {
 
     public static final String API_URL = "https://connect.urbanairship.com/api/events/";
+    public static final String EU_API_URL = "https://connect.asnapieu.com/api/events/";
 
     private Constants() { }
 }

--- a/src/main/java/com/urbanairship/connect/client/StreamConnection.java
+++ b/src/main/java/com/urbanairship/connect/client/StreamConnection.java
@@ -89,6 +89,13 @@ public class StreamConnection implements AutoCloseable {
         this.url = url;
     }
 
+    public StreamConnection(StreamQueryDescriptor descriptor,
+                            AsyncHttpClient client,
+                            ConnectionRetryStrategy connectionRetryStrategy,
+                            Consumer<String> eventConsumer) {
+        this(descriptor, client, connectionRetryStrategy, eventConsumer, descriptor.getEndpointUrl());
+    }
+
     /**
      * Opens up a connection to Urban Airship Connect and begins consuming data and passing it to the configured consumer
      * starting at the position specified by the startPosition parameter.

--- a/src/main/java/com/urbanairship/connect/client/StreamConsumeTask.java
+++ b/src/main/java/com/urbanairship/connect/client/StreamConsumeTask.java
@@ -269,7 +269,7 @@ public final class StreamConsumeTask implements Runnable {
         public StreamConnection get(StreamQueryDescriptor descriptor,
                                     AsyncHttpClient client,
                                     Consumer<String> eventConsumer) {
-            return new StreamConnection(descriptor, client, CONNECTION_RETRY_STRATEGY, eventConsumer, Constants.API_URL);
+            return new StreamConnection(descriptor, client, CONNECTION_RETRY_STRATEGY, eventConsumer);
         }
     }
 

--- a/src/main/java/com/urbanairship/connect/client/model/StreamQueryDescriptor.java
+++ b/src/main/java/com/urbanairship/connect/client/model/StreamQueryDescriptor.java
@@ -7,9 +7,11 @@ package com.urbanairship.connect.client.model;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.urbanairship.connect.client.Constants;
 import com.urbanairship.connect.client.StreamConnection;
 import com.urbanairship.connect.client.model.request.Subset;
 import com.urbanairship.connect.client.model.request.filters.Filter;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -25,6 +27,7 @@ public final class StreamQueryDescriptor {
     private final Set<Filter> filters;
     private final Optional<Subset> subset;
     private final Optional<Boolean> offsetUpdatesEnabled;
+    private final String endpointUrl;
 
     /**
      * StreamDescriptor builder
@@ -34,11 +37,12 @@ public final class StreamQueryDescriptor {
         return new Builder();
     }
 
-    private StreamQueryDescriptor(Creds creds, Set<Filter> filters, Optional<Subset> subset, Optional<Boolean> offsetUpdatesEnabled) {
+    private StreamQueryDescriptor(Creds creds, Set<Filter> filters, Optional<Subset> subset, Optional<Boolean> offsetUpdatesEnabled, String endpointUrl) {
         this.creds = creds;
         this.filters = filters;
         this.subset = subset;
         this.offsetUpdatesEnabled = offsetUpdatesEnabled;
+        this.endpointUrl = endpointUrl;
     }
 
     /**
@@ -77,23 +81,30 @@ public final class StreamQueryDescriptor {
         return offsetUpdatesEnabled;
     }
 
+    /**
+     * Get Configured endpoint URL
+     *
+     * @return endpoint URL
+     */
+    public String getEndpointUrl() {
+        return endpointUrl;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         StreamQueryDescriptor that = (StreamQueryDescriptor) o;
         return Objects.equals(creds, that.creds) &&
                 Objects.equals(filters, that.filters) &&
-                Objects.equals(subset, that.subset);
+                Objects.equals(subset, that.subset) &&
+                Objects.equals(offsetUpdatesEnabled, that.offsetUpdatesEnabled) &&
+                Objects.equals(endpointUrl, that.endpointUrl);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(creds, filters, subset);
+        return Objects.hash(creds, filters, subset, offsetUpdatesEnabled, endpointUrl);
     }
 
     public static final class Builder {
@@ -103,6 +114,7 @@ public final class StreamQueryDescriptor {
         private Creds creds = null;
         private Subset subset = null;
         private Optional<Boolean> offsetUpdatesEnabled = Optional.absent();
+        private String endpointUrl = Constants.API_URL;
 
         private Builder() {}
 
@@ -159,14 +171,25 @@ public final class StreamQueryDescriptor {
             return this;
         }
 
+        public Builder setEndpointUrl(String url) {
+            this.endpointUrl = url;
+            return this;
+        }
+
         /**
          * Builder a StreamDescriptor object.
          * @return StreamDescriptor
          */
         public StreamQueryDescriptor build() {
             Preconditions.checkNotNull(creds, "Creds object must be provided");
+            Preconditions.checkArgument(StringUtils.isNotBlank(endpointUrl), "Endpoint URL must not be null");
 
-            return new StreamQueryDescriptor(creds, ImmutableSet.copyOf(filters), Optional.fromNullable(subset), offsetUpdatesEnabled);
+            return new StreamQueryDescriptor(
+                    creds,
+                    ImmutableSet.copyOf(filters),
+                    Optional.fromNullable(subset),
+                    offsetUpdatesEnabled,
+                    endpointUrl);
         }
     }
 }


### PR DESCRIPTION
### What does this do and why?
This change adds support for specifying the URL used to stream data from Connect(RTDS).

### Additional notes for reviewers
* N/A

### Testing
- [ ✓ ] I wrote tests covering these changes  
- [ ✓ ] I ran the full test suite and it passed

### Test run results, including date and time:

2019-05-29 11:30 PDT Tests run: 55, Failures: 0, Errors: 0, Skipped: 0

### Urban Airship Contribution Agreement
https://docs.urbanairship.com/contribution-agreement/

- [✓ ] I've filled out and signed UA's contribution agreement form.

### Screenshots
* N/A
