### PR TITLE
-bintray +mvnrepository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,14 @@
     </developer>
   </developers>
 
+
+  <distributionManagement>
+    <repository>
+      <id>mvnrepository-central-connect-client</id>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <build>
     <plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,15 +30,9 @@
     </developer>
   </developers>
 
-  <distributionManagement>
-    <repository>
-      <id>bintray-repo-connect-client</id>
-      <url>https://api.bintray.com/maven/urbanairship/java-client/connect-client/;publish=1</url>
-    </repository>
-  </distributionManagement>
-
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -48,6 +42,38 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+          <executions>
+              <execution>
+                  <id>sign-artifacts</id>
+                  <phase>verify</phase>
+                  <goals>
+                      <goal>sign</goal>
+                  </goals>
+                  <configuration>
+                      <gpgArguments>
+                          <arg>--pinentry-mode</arg>
+                          <arg>loopback</arg>
+                      </gpgArguments>
+                  </configuration>
+              </execution>
+          </executions>
+      </plugin>
+
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5</version>
+          <configuration>
+              <pushChanges>false</pushChanges>
+              <arguments>-Dgpg.passphrase=${local.gpg.passphrase}</arguments>
+          </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Moving distribution from Bintray to mvnrepository.
- Remove `distributionManagement` (Bintray) 
- Add maven-gpg-plugin 
- Add maven-release-plugin

Copied from[ java-library.](https://github.com/urbanairship/java-library/blob/5d938959c708a8780971b1fa31800e1ac3319891/pom.xml#L54-L83)
https://urbanairship.atlassian.net/browse/INFRA-4250
